### PR TITLE
Add dark mode toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,4 @@ My personal website showcasing my research projects and professional experience 
 - CSS3
 - JavaScript
 - Font Awesome for icons
+- Light/Dark theme toggle with persistent preference

--- a/index.html
+++ b/index.html
@@ -19,6 +19,7 @@
                 <li><a href="#contact">Contact</a></li>
                 <li><a href="https://baranbingol1.github.io/" target="_blank">Blog</a></li>
             </ul>
+            <button id="theme-toggle" aria-label="Toggle dark mode">🌓</button>
         </div>
     </nav>
 

--- a/script.js
+++ b/script.js
@@ -137,3 +137,23 @@ document.querySelectorAll('section').forEach(section => {
     section.style.transition = 'all 0.6s ease-out';
     observer.observe(section);
 });
+
+// Theme toggle
+const themeToggle = document.getElementById('theme-toggle');
+
+function setTheme(theme) {
+    if (theme === 'dark') {
+        document.body.classList.add('dark-mode');
+    } else {
+        document.body.classList.remove('dark-mode');
+    }
+    localStorage.setItem('theme', theme);
+}
+
+const savedTheme = localStorage.getItem('theme') || 'light';
+setTheme(savedTheme);
+
+themeToggle.addEventListener('click', () => {
+    const newTheme = document.body.classList.contains('dark-mode') ? 'light' : 'dark';
+    setTheme(newTheme);
+});

--- a/styles.css
+++ b/styles.css
@@ -1,9 +1,25 @@
 :root {
+    /* Light (Claude-style) palette */
     --primary-color: #2d3436;
     --secondary-color: #0984e3;
     --text-color: #2d3436;
     --background-color: #ffffff;
     --accent-color: #74b9ff;
+    --hero-gradient: linear-gradient(135deg, #ffffff 0%, #f5f7fa 100%);
+    --card-background: #ffffff;
+    --navbar-bg: rgba(255, 255, 255, 0.95);
+}
+
+body.dark-mode {
+    /* Spotify inspired dark theme */
+    --primary-color: #ffffff;
+    --secondary-color: #1db954;
+    --text-color: #e0e0e0;
+    --background-color: #121212;
+    --accent-color: #1ed760;
+    --hero-gradient: linear-gradient(135deg, #181818 0%, #121212 100%);
+    --card-background: #1e1e1e;
+    --navbar-bg: #181818;
 }
 
 * {
@@ -16,7 +32,9 @@ body {
     font-family: 'Inter', sans-serif;
     line-height: 1.6;
     color: var(--text-color);
+    background-color: var(--background-color);
     overflow-x: hidden;
+    transition: background-color 0.3s ease, color 0.3s ease;
 }
 
 .container {
@@ -30,7 +48,7 @@ body {
     position: fixed;
     top: 0;
     width: 100%;
-    background-color: rgba(255, 255, 255, 0.95);
+    background-color: var(--navbar-bg, rgba(255, 255, 255, 0.95));
     box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
     z-index: 1000;
 }
@@ -63,6 +81,19 @@ body {
     transition: color 0.3s ease;
 }
 
+#theme-toggle {
+    background: none;
+    border: none;
+    font-size: 1.2rem;
+    cursor: pointer;
+    color: var(--text-color);
+    transition: color 0.3s ease;
+}
+
+#theme-toggle:hover {
+    color: var(--secondary-color);
+}
+
 .nav-links a:hover {
     color: var(--secondary-color);
 }
@@ -73,7 +104,7 @@ body {
     display: flex;
     align-items: center;
     justify-content: center;
-    background: linear-gradient(135deg, #f5f7fa 0%, #c3cfe2 100%);
+    background: var(--hero-gradient);
     padding-top: 60px;
 }
 
@@ -182,7 +213,7 @@ body {
 /* Research Section */
 .research {
     padding: 6rem 0;
-    background-color: #f8f9fa;
+    background-color: var(--background-color);
 }
 
 .research h2 {
@@ -200,7 +231,7 @@ body {
 }
 
 .research-item {
-    background: white;
+    background: var(--card-background, #ffffff);
     padding: 2rem;
     border-radius: 10px;
     box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);


### PR DESCRIPTION
## Summary
- implement light/dark color variables
- style hero background with theme gradients
- add theme toggle button and persistence
- document theme support in README

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_683f59c7fa808323972538a87820a63c