### PR TITLE
Fix dark mode tag visibility

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -10,6 +10,7 @@
     --navbar-bg: rgba(255, 255, 255, 0.95);
     --footer-bg: #2d3436;
     --button-text-color: #ffffff;
+    --tag-background: #e9ecef;
 }
 
 body.dark-mode {
@@ -24,6 +25,7 @@ body.dark-mode {
     --navbar-bg: #181818;
     --footer-bg: #181818;
     --button-text-color: #ffffff;
+    --tag-background: #2b2b2b;
 }
 
 * {
@@ -307,7 +309,7 @@ body {
 }
 
 .tag {
-    background-color: #e9ecef;
+    background-color: var(--tag-background);
     color: var(--text-color);
     padding: 0.3rem 0.8rem;
     border-radius: 15px;


### PR DESCRIPTION
## Summary
- define theme variable for tag background
- use tag background variable so text remains visible in dark mode

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f605a989c8323826bd4c6d8d69c93